### PR TITLE
Add local web server with REST API

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 ## SpaceTime - Python Overview
-The SpaceTime box contains a Raspberry Pi and a custom AVR-based PCB called [SpaceTime](../README.md). The Raspberry Pi runs a Python program that performs NTP time sync and facilitates network communication between SpaceTime and both the [isvhsopen.com Web API](http://isvhsopen.com/api/status/) ([GitHub](https://github.com/vhs/isvhsopen)) and the [Hackspace API](http://api.hackspace.ca) ([GitHub](https://github.com/vhs/api)). Communication with the Hackspace API is mostly deprecated in favour of the new isvhsopen Web API, but is still used to log the Raspberry Pi's local IP address. A web server also provides a REST interface on port 80 to change the Open status from within the VHS local network.
+The SpaceTime box contains a Raspberry Pi and a custom AVR-based PCB called [SpaceTime](../README.md). The Raspberry Pi runs a Python program that performs NTP time sync and facilitates network communication between SpaceTime and both the [isvhsopen.com Web API](http://isvhsopen.com/api/status/) ([GitHub](https://github.com/vhs/isvhsopen)) and the [Hackspace API](http://api.hackspace.ca) ([GitHub](https://github.com/vhs/api)). Communication with the Hackspace API is mostly deprecated in favour of the new isvhsopen Web API, but is still used to log the Raspberry Pi's local IP address. A local web server also provides a REST interface on port 80 to change the status from within the VHS local network.
 
-The Raspberry Pi username/password and if hostname ```isvhsopen-spacetime``` doesn't work, local IP address can be found on the physical SpaceTime box. IP address is also on the Hackspace API as [spacetime_ip](http://api.hackspace.ca/s/vhs/data/spacetime_ip.txt). To connect to the Raspberry Pi from the local network, make sure you are on the same subnet by ensuring that `spacetime_ip` starts the same as your computer's IP. Then connect using any SSH client, such as `putty` or the Linux command line `ssh`.
+The Raspberry Pi username/password and local IP address can be found on the physical SpaceTime box. The device is also configured with hostname ```isvhsopen-spacetime```. IP address is also on the Hackspace API as [spacetime_ip](http://api.hackspace.ca/s/vhs/data/spacetime_ip.txt). To connect to the Raspberry Pi from the local network, make sure you are on the same subnet by ensuring that `spacetime_ip` starts the same as your computer's IP. Then connect using any SSH client, such as `putty` or the Linux command line `ssh`.
 
 ## Configuring Raspberry Pi from scratch
 
@@ -79,6 +79,27 @@ Please do not push changes to GitHub that include the API Key. This key should o
 
 #### Configure VHS API variables
 Find and edit the Hackspace API variable names used at the top of `main.py`. With the new isvhsopen.com API (independent of the Hackspace API), the only variable we still update directly on api.hackspace.ca is the one that stores the Raspberry Pi's local IP.
+
+#### Set hostname for Raspberry Pi
+To configure the Raspberry Pi with hostname ```isvhsopen-spacetime```:
+Edit the 127.0.1.1 entry in `/etc/hosts`
+```Shell
+> sudo nano /etc/hosts
+
+127.0.1.1       isvhsopen-spacetime
+```
+Replace the current hostname in `/etc/hostname` with ```isvhsopen-spacetime```
+```Shell
+> sudo nano /etc/hostname
+
+isvhsopen-spacetime
+```
+Commit the changes and reboot
+```Shell
+> sudo /etc/init.d/hostname.sh
+> sudo reboot
+```
+Now you should be able to ssh into the Raspberry Pi using either its [local IP address](http://api.hackspace.ca/s/vhs/data/spacetime_ip.txt) or hostname (```isvhsopen-spacetime```).
 
 #### Testing
 To run unit tests from command line:

--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 ## SpaceTime - Python Overview
-The SpaceTime box contains a Raspberry Pi and a custom AVR-based PCB called [SpaceTime](../README.md). The Raspberry Pi runs a Python program that performs NTP time sync and facilitates network communication between SpaceTime and both the [isvhsopen.com Web API](http://isvhsopen.com/api/status/) ([GitHub](https://github.com/vhs/isvhsopen)) and the [Hackspace API](http://api.hackspace.ca) ([GitHub](https://github.com/vhs/api)). Communication with the Hackspace API is mostly deprecated in favour of the new isvhsopen Web API, but is still used to log the Raspberry Pi's local IP address.
+The SpaceTime box contains a Raspberry Pi and a custom AVR-based PCB called [SpaceTime](../README.md). The Raspberry Pi runs a Python program that performs NTP time sync and facilitates network communication between SpaceTime and both the [isvhsopen.com Web API](http://isvhsopen.com/api/status/) ([GitHub](https://github.com/vhs/isvhsopen)) and the [Hackspace API](http://api.hackspace.ca) ([GitHub](https://github.com/vhs/api)). Communication with the Hackspace API is mostly deprecated in favour of the new isvhsopen Web API, but is still used to log the Raspberry Pi's local IP address. A web server also provides a REST interface on port 80 to change the Open status from within the VHS local network.
 
-The Raspberry Pi username/password and local IP address can be found on the physical SpaceTime box. IP address is also on the Hackspace API as [spacetime_ip](http://api.hackspace.ca/s/vhs/data/spacetime_ip.txt). To connect to the Raspberry Pi from the local network, make sure you are on the same subnet by ensuring that `spacetime_ip` starts the same as your computer's IP. Then connect using any SSH client, such as `putty` or the Linux command line `ssh`.
+The Raspberry Pi username/password and if hostname ```isvhsopen-spacetime``` doesn't work, local IP address can be found on the physical SpaceTime box. IP address is also on the Hackspace API as [spacetime_ip](http://api.hackspace.ca/s/vhs/data/spacetime_ip.txt). To connect to the Raspberry Pi from the local network, make sure you are on the same subnet by ensuring that `spacetime_ip` starts the same as your computer's IP. Then connect using any SSH client, such as `putty` or the Linux command line `ssh`.
 
 ## Configuring Raspberry Pi from scratch
 
@@ -10,6 +10,7 @@ The Raspberry Pi username/password and local IP address can be found on the phys
 ```Shell
 > sudo easy_install -U pyserial
 > sudo easy_install -U requests
+> sudo easy_install -U web.py
 ```
 
 #### Enable UART serial on Raspberry Pi
@@ -64,8 +65,9 @@ Add to the end of `/etc/rc.local`
 ```Shell
 > sudo nano /etc/rc.local
 
-python /usr/local/bin/SpaceTime/python/main.py &
+python /usr/local/bin/SpaceTime/python/main.py 80 &
 ```
+The parameter after main.py is the port (80) for which to host the RESTful web server.
 
 #### Get isvhsopen Web API Key
 Refer to the [isvhsopen.com API on GitHub](https://github.com/vhs/isvhsopen) to obtain an API Key. Once obtained, run this command, replacing ```[Generated Key]``` with the actual API Key. HTTP POST commands to update the API will fail without a valid API Key.
@@ -102,6 +104,9 @@ Detach:		Ctrl-a d
 Reattach:	screen -x
 List:		screen -ls
 ```
+
+#### Using the REST API
+The Python code hosts a web server on the local network. Anyone connected to the VHS network (anyone physically at the space) can connect to http://isvhsopen-spacetime/ to open the space, close the space, or change the closing time. Network admins, please do not expose this web service to the public internet. If you cannot access the URL, try [spacetime_ip](http://api.hackspace.ca/s/vhs/data/spacetime_ip.txt) on the Hackspace API and confirm that you're on the same network. Also try on port 8080, as this is the default if one is not specified on startup.
 
 ### TODO List
 

--- a/python/main.py
+++ b/python/main.py
@@ -3,6 +3,7 @@ import socket
 from spacetime import SpaceTime
 from vhsapi import VHSApi #api.hackspace.ca
 from webapi import WebApi #isvhsopen.com/api/status/
+from restserv import RestServ #Webserver for REST API to allow updates from the VHS network 
 from timeutil import *
 
 dbg_showAllSerial = False #If true, prints out all received serial messages
@@ -125,6 +126,9 @@ def setup():
   while not st.IsConnected():
     print('Failed to init Serial connection with SpaceTime. Trying again...')
   print('Initialized!')
+  
+  print('Initializing webserver for REST API (only available to LAN)')
+  RestServ(st)
   
   #Query Closing time (this is the only time we do this)
   #in case RPi was rebooted but SpaceTime wasn't.

--- a/python/restserv.py
+++ b/python/restserv.py
@@ -1,0 +1,42 @@
+import web
+from timeutil import *
+
+#SpaceTime object, defined when RestServ() is called
+spacetime = None
+  
+urls = (
+  '/', 'index',
+  r'/set/open/(\d\d?):?(\d\d)', 'setopen',
+  '/set/closed?/?', 'setclosed'
+)
+
+#Initializes a webserver with a restful API to control the SpaceTime board.
+#Intended to be made available on the local VHS network, but not over the internet.
+#Parameter st should be an initialized SpaceTime object.
+def RestServ(st):
+  global spacetime
+  spacetime = st
+  app = web.application(urls, globals())
+  app.run()
+
+class index:
+  def GET(self):
+    return "SpaceTime REST API\r\n" \
+       + "/set/open/15:30 - Sets SpaceTime to stay open until 15:30\r\n" \
+       + "/set/closed     - Sets SpaceTime to closed"
+
+class setopen:
+  def GET(self, hours, mins):
+    #Make a HH:MM:SS time string
+    timestr = hours.zfill(2) + ":" + mins + ":00"
+    if IsTimeStr(timestr):
+      #Closing time is ID 1
+      spacetime.SetTime(1, StrToTime(timestr))
+      return "SpaceTime set to " + timestr + "."
+    return timestr + " is not a valid time."
+
+class setclosed:
+  def GET(self):
+    #Closing time is ID 1
+    spacetime.ClearTime(1)
+    return "SpaceTime set to closed."

--- a/python/timeutil.py
+++ b/python/timeutil.py
@@ -29,12 +29,17 @@ def TimeOffsetSeconds(t1, t2):
   return diff
 
 def IsTimeStr( str ):
-  #Basic test for time-formatted string, returns True if format matches "dd:dd:dd"
-  #where d is any digit.
+  #Basic test for time-formatted string, returns True if format matches "HH:MM:SS"
+  #of a 24-hour formatted clock.
   if len(str) == 8 and ':' == str[2] == str[5]:
-    for i in [0, 1, 3, 4, 6, 7]:
+    for i in [0, 1, 4, 7]:
       if not '0' <= str[i] <= '9':
         return False
+    for i in [3, 6]: #10's digits cannot go above 5
+      if not '0' <= str[i] <= '5':
+        return False
+    if str[0] > '2' or (str[0] == '2' and str[1] > '3'): #24-hour clock's hour part must be < 24
+      return False
     return True
   return False
   


### PR DESCRIPTION
The Python code now includes a webserver (see restserv.py) that allows
people to open, close, and update the closing time of SpaceTime. This is
limited to the local network, and should not be exposed to the internet.
