### PR TITLE
Make web service a background task

### DIFF
--- a/python/restserv.py
+++ b/python/restserv.py
@@ -1,4 +1,5 @@
 import web
+import threading
 from timeutil import *
 
 #SpaceTime object, defined when RestServ() is called
@@ -16,8 +17,15 @@ urls = (
 def RestServ(st):
   global spacetime
   spacetime = st
-  app = web.application(urls, globals())
-  app.run()
+  th = RestServThread()
+  th.daemon = True
+  th.start()
+
+#The web server runs in a thread so that app.run() doesn't block all other execution.
+class RestServThread(threading.Thread):
+  def run(self):
+    app = web.application(urls, globals())
+    app.run()
 
 class index:
   def GET(self):

--- a/python/test_webapi.py
+++ b/python/test_webapi.py
@@ -40,7 +40,7 @@ class TestWebApi(unittest.TestCase):
     #the update; we don't wait and then query to verify, but just trust it.
     v = WebApi()
     j = v.Update('open', '12:34')
-    self.assertTrue(j['status'] == 'open' and j['openUntil'].find('12:34:00') == 11)
+    self.assertTrue(j['status'] == 'open' and j['openUntil'].find('12:34:00') == 11) #TODO: Timezone is different server-side now, so this check fails
     j = v.Update('closed')
     self.assertTrue(j['status'] == 'closed' and j.get('openUntil') == None)
     


### PR DESCRIPTION
I didn't realize that starting the web application blocked execution for
everything else. It's now running in its own thread.
